### PR TITLE
jQuery Mobile 1.2.0 compability

### DIFF
--- a/index.html
+++ b/index.html
@@ -67,7 +67,7 @@
 
 	<div data-role="page" id="main_page" data-theme="a">
 
-		<div data-role="header" data-position="fixed">
+		<div data-role="header" data-position="fixed" data-tap-toggle="false" data-update-page-padding="false">
 			<a href="#" data-slidemenu="#slidemenu" data-slideopen="false" data-icon="smico" data-corners="false" data-iconpos="notext">Menu</a>
 			<h1>Slide Menu</h1>
 		</div>
@@ -86,7 +86,7 @@
 	
 	<div data-role="page" id="another_page" data-theme="a">
 
-		<div data-role="header" data-position="fixed">
+		<div data-role="header" data-position="fixed" data-tap-toggle="false" data-update-page-padding="false">
 			<a href="#" data-slidemenu="#slidemenu" data-slideopen="false" data-icon="smico" data-corners="false" data-iconpos="notext">Menu</a>
 			<h1>Slide Menu</h1>
 		</div>
@@ -101,7 +101,7 @@
 	
 	<div data-role="page" id="another_page2" data-theme="a">
 
-		<div data-role="header" data-position="fixed">
+		<div data-role="header" data-position="fixed" data-tap-toggle="false" data-update-page-padding="false">
 			<a href="#" data-slidemenu="#slidemenu" data-slideopen="false" data-icon="smico" data-corners="false" data-iconpos="notext">Menu</a>
 			<h1>Slide Menu</h1>
 		</div>
@@ -116,7 +116,7 @@
 	
 	<div data-role="page" id="another_page3" data-theme="a">
 
-		<div data-role="header" data-position="fixed">
+		<div data-role="header" data-position="fixed" data-tap-toggle="false" data-update-page-padding="false">
 			<a href="#" data-slidemenu="#slidemenu" data-slideopen="false" data-icon="smico" data-corners="false" data-iconpos="notext">Menu</a>
 			<h1>Slide Menu</h1>
 		</div>

--- a/js/jqm.slidemenu.js
+++ b/js/jqm.slidemenu.js
@@ -3,12 +3,6 @@ $(document).on("pageinit", function(e){
 	$("#"+ $(e.target).attr('id') +" :jqmData(slidemenu)").addClass('slidemenu_btn');
 	var sm = $($("#"+ $(e.target).attr('id') +" :jqmData(slidemenu)").data('slidemenu'));
 	sm.addClass('slidemenu');
-	
-	$(document).on("click",".ui-page-active", function(e){
-		if (sm.data('slideopen')) {
-			$(".ui-page-active :jqmData(role='header')").removeClass('ui-fixed-hidden');
-		}
-	});
 
 	$(document).on("swipeleft swiperight",".ui-page-active", function(e){
 		console.log('b');

--- a/test.html
+++ b/test.html
@@ -67,7 +67,7 @@
 
 	<div data-role="page" id="main_page" data-theme="a">
 
-		<div data-role="header" data-position="fixed">
+		<div data-role="header" data-position="fixed" data-tap-toggle="false" data-update-page-padding="false">
 			<a href="#" data-slidemenu="#slidemenu" data-slideopen="false" data-icon="smico" data-corners="false" data-iconpos="notext">Menu</a>
 			<h1>Slide Menu</h1>
 		</div>
@@ -86,7 +86,7 @@
 	
 	<div data-role="page" id="another_page" data-theme="a">
 
-		<div data-role="header" data-position="fixed">
+		<div data-role="header" data-position="fixed" data-tap-toggle="false" data-update-page-padding="false">
 			<a href="#" data-slidemenu="#slidemenu" data-slideopen="false" data-icon="smico" data-corners="false" data-iconpos="notext">Menu</a>
 			<h1>Slide Menu</h1>
 		</div>
@@ -101,7 +101,7 @@
 	
 	<div data-role="page" id="another_page2" data-theme="a">
 
-		<div data-role="header" data-position="fixed">
+		<div data-role="header" data-position="fixed" data-tap-toggle="false" data-update-page-padding="false">
 			<a href="#" data-slidemenu="#slidemenu" data-slideopen="false" data-icon="smico" data-corners="false" data-iconpos="notext">Menu</a>
 			<h1>Slide Menu</h1>
 		</div>
@@ -116,7 +116,7 @@
 	
 	<div data-role="page" id="another_page3" data-theme="a">
 
-		<div data-role="header" data-position="fixed">
+		<div data-role="header" data-position="fixed" data-tap-toggle="false" data-update-page-padding="false">
 			<a href="#" data-slidemenu="#slidemenu" data-slideopen="false" data-icon="smico" data-corners="false" data-iconpos="notext">Menu</a>
 			<h1>Slide Menu</h1>
 		</div>


### PR DESCRIPTION
I found some problems in the slide menu when using it with jQuery Mobile 1.2.0 (to be honest, I haven't tried it with any older versions of jQM as I just started out implementing the slide menu in my project.
The problem being that whenever you click or tap in the active page with the menu expanded the header of the page would jump to the right (by as many pixels as the width of the menu itself). 

I found code in jqm.slidemenu.js that looked like a workaround (removing the class .ui-fixed-hidden on click) but this did not work for me. However, by adding the data attributes tap-toggle=false and update-page-padding=false to the page div it works as expected.

Feel free to implement the changes if it doesn't break anything else and if the behavior I introduced to the page is allright.
